### PR TITLE
Add all Configuration properties

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/mybatis/deployment/MyBatisProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/mybatis/deployment/MyBatisProcessor.java
@@ -136,12 +136,11 @@ class MyBatisProcessor {
             }
         }
 
-        return new SqlSessionFactoryBuildItem(recorder.createSqlSessionFactory(
-                myBatisRuntimeConfig.environment,
-                myBatisRuntimeConfig.transactionFactory,
-                dataSourceName,
-                myBatisRuntimeConfig.mapUnderscoreToCamelCase,
-                mappers));
+        return new SqlSessionFactoryBuildItem(
+                recorder.createSqlSessionFactory(
+                        myBatisRuntimeConfig,
+                        dataSourceName,
+                        mappers));
     }
 
     @Record(ExecutionTime.STATIC_INIT)

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 1.12.0.Final
+:quarkus-version: 1.12.1.Final
 :quarkus-mybatis-version: 0.0.4
 
 :mybatis-root-url: https://mybatis.org/mybatis-3/

--- a/docs/modules/ROOT/pages/includes/quarkus-mybatis.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mybatis.adoc
@@ -44,15 +44,6 @@ MyBatis initial sql
 |
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.map-underscore-to-camel-case]]`link:#quarkus-mybatis_quarkus.mybatis.map-underscore-to-camel-case[quarkus.mybatis.map-underscore-to-camel-case]`
-
-[.description]
---
-MyBatis mapUnderscoreToCamelCase
---|boolean 
-|`false`
-
-
 a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.cache-enabled]]`link:#quarkus-mybatis_quarkus.mybatis.cache-enabled[quarkus.mybatis.cache-enabled]`
 
 [.description]
@@ -168,6 +159,15 @@ a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.safe-re
 MyBatis safeResultHandlerEnabled
 --|boolean 
 |`true`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.map-underscore-to-camel-case]]`link:#quarkus-mybatis_quarkus.mybatis.map-underscore-to-camel-case[quarkus.mybatis.map-underscore-to-camel-case]`
+
+[.description]
+--
+MyBatis mapUnderscoreToCamelCase
+--|boolean 
+|`false`
 
 
 a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.multiple-result-sets-enabled]]`link:#quarkus-mybatis_quarkus.mybatis.multiple-result-sets-enabled[quarkus.mybatis.multiple-result-sets-enabled]`

--- a/docs/modules/ROOT/pages/includes/quarkus-mybatis.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mybatis.adoc
@@ -49,7 +49,268 @@ a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.map-und
 [.description]
 --
 MyBatis mapUnderscoreToCamelCase
---|string 
+--|boolean 
 |`false`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.cache-enabled]]`link:#quarkus-mybatis_quarkus.mybatis.cache-enabled[quarkus.mybatis.cache-enabled]`
+
+[.description]
+--
+MyBatis cacheEnabled
+--|boolean 
+|`true`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.lazy-loading-enabled]]`link:#quarkus-mybatis_quarkus.mybatis.lazy-loading-enabled[quarkus.mybatis.lazy-loading-enabled]`
+
+[.description]
+--
+MyBatis lazyLoadingEnabled
+--|boolean 
+|`false`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.aggressive-lazy-loading]]`link:#quarkus-mybatis_quarkus.mybatis.aggressive-lazy-loading[quarkus.mybatis.aggressive-lazy-loading]`
+
+[.description]
+--
+MyBatis aggressiveLazyLoading
+--|boolean 
+|`false`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.use-column-label]]`link:#quarkus-mybatis_quarkus.mybatis.use-column-label[quarkus.mybatis.use-column-label]`
+
+[.description]
+--
+MyBatis useColumnLabel
+--|boolean 
+|`true`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.use-generated-keys]]`link:#quarkus-mybatis_quarkus.mybatis.use-generated-keys[quarkus.mybatis.use-generated-keys]`
+
+[.description]
+--
+MyBatis useGeneratedKeys
+--|boolean 
+|`false`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.auto-mapping-behavior]]`link:#quarkus-mybatis_quarkus.mybatis.auto-mapping-behavior[quarkus.mybatis.auto-mapping-behavior]`
+
+[.description]
+--
+MyBatis autoMappingBehavior
+--|`none`, `partial`, `full` 
+|`partial`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.auto-mapping-unknown-column-behavior]]`link:#quarkus-mybatis_quarkus.mybatis.auto-mapping-unknown-column-behavior[quarkus.mybatis.auto-mapping-unknown-column-behavior]`
+
+[.description]
+--
+MyBatis autoMappingUnknownColumnBehavior
+--|`none`, `warning`, `failing` 
+|`none`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.default-executor-type]]`link:#quarkus-mybatis_quarkus.mybatis.default-executor-type[quarkus.mybatis.default-executor-type]`
+
+[.description]
+--
+MyBatis defaultExecutorType
+--|`simple`, `reuse`, `batch` 
+|`simple`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.default-statement-timeout]]`link:#quarkus-mybatis_quarkus.mybatis.default-statement-timeout[quarkus.mybatis.default-statement-timeout]`
+
+[.description]
+--
+MyBatis defaultStatementTimeout
+--|int 
+|
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.default-fetch-size]]`link:#quarkus-mybatis_quarkus.mybatis.default-fetch-size[quarkus.mybatis.default-fetch-size]`
+
+[.description]
+--
+MyBatis defaultFetchSize
+--|int 
+|
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.default-result-set-type]]`link:#quarkus-mybatis_quarkus.mybatis.default-result-set-type[quarkus.mybatis.default-result-set-type]`
+
+[.description]
+--
+MyBatis defaultResultSetType
+--|`default`, `forward-only`, `scroll-insensitive`, `scroll-sensitive` 
+|
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.safe-row-bounds-enabled]]`link:#quarkus-mybatis_quarkus.mybatis.safe-row-bounds-enabled[quarkus.mybatis.safe-row-bounds-enabled]`
+
+[.description]
+--
+MyBatis safeRowBoundsEnabled
+--|boolean 
+|`false`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.safe-result-handler-enabled]]`link:#quarkus-mybatis_quarkus.mybatis.safe-result-handler-enabled[quarkus.mybatis.safe-result-handler-enabled]`
+
+[.description]
+--
+MyBatis safeResultHandlerEnabled
+--|boolean 
+|`true`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.multiple-result-sets-enabled]]`link:#quarkus-mybatis_quarkus.mybatis.multiple-result-sets-enabled[quarkus.mybatis.multiple-result-sets-enabled]`
+
+[.description]
+--
+MyBatis multipleResultSetsEnabled
+--|boolean 
+|`true`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.local-cache-scope]]`link:#quarkus-mybatis_quarkus.mybatis.local-cache-scope[quarkus.mybatis.local-cache-scope]`
+
+[.description]
+--
+MyBatis localCacheScope
+--|`session`, `statement` 
+|`session`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.jdbc-type-for-null]]`link:#quarkus-mybatis_quarkus.mybatis.jdbc-type-for-null[quarkus.mybatis.jdbc-type-for-null]`
+
+[.description]
+--
+MyBatis jdbcTypeForNull
+--|`array`, `bit`, `tinyint`, `smallint`, `integer`, `bigint`, `float`, `real`, `double`, `numeric`, `decimal`, `char`, `varchar`, `longvarchar`, `date`, `time`, `timestamp`, `binary`, `varbinary`, `longvarbinary`, `null`, `other`, `blob`, `clob`, `boolean`, `cursor`, `undefined`, `nvarchar`, `nchar`, `nclob`, `struct`, `java-object`, `distinct`, `ref`, `datalink`, `rowid`, `longnvarchar`, `sqlxml`, `datetimeoffset`, `time-with-timezone`, `timestamp-with-timezone` 
+|`other`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.lazy-load-trigger-methods]]`link:#quarkus-mybatis_quarkus.mybatis.lazy-load-trigger-methods[quarkus.mybatis.lazy-load-trigger-methods]`
+
+[.description]
+--
+MyBatis lazyLoadTriggerMethods
+--|list of string 
+|`equals,clone,hashCode,toString`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.default-scripting-language]]`link:#quarkus-mybatis_quarkus.mybatis.default-scripting-language[quarkus.mybatis.default-scripting-language]`
+
+[.description]
+--
+MyBatis defaultScriptingLanguage
+--|string 
+|`org.apache.ibatis.scripting.xmltags.XMLLanguageDriver`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.default-enum-type-handler]]`link:#quarkus-mybatis_quarkus.mybatis.default-enum-type-handler[quarkus.mybatis.default-enum-type-handler]`
+
+[.description]
+--
+MyBatis defaultEnumTypeHandler
+--|string 
+|`org.apache.ibatis.type.EnumTypeHandler`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.call-setters-on-nulls]]`link:#quarkus-mybatis_quarkus.mybatis.call-setters-on-nulls[quarkus.mybatis.call-setters-on-nulls]`
+
+[.description]
+--
+MyBatis callSettersOnNulls
+--|boolean 
+|`false`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.return-instance-for-empty-row]]`link:#quarkus-mybatis_quarkus.mybatis.return-instance-for-empty-row[quarkus.mybatis.return-instance-for-empty-row]`
+
+[.description]
+--
+MyBatis returnInstanceForEmptyRow
+--|boolean 
+|`false`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.log-prefix]]`link:#quarkus-mybatis_quarkus.mybatis.log-prefix[quarkus.mybatis.log-prefix]`
+
+[.description]
+--
+MyBatis logPrefix
+--|string 
+|
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.log-impl]]`link:#quarkus-mybatis_quarkus.mybatis.log-impl[quarkus.mybatis.log-impl]`
+
+[.description]
+--
+MyBatis logImpl
+--|string 
+|
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.proxy-factory]]`link:#quarkus-mybatis_quarkus.mybatis.proxy-factory[quarkus.mybatis.proxy-factory]`
+
+[.description]
+--
+MyBatis proxyFactory
+--|string 
+|`JAVASSIST`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.vfs-impl]]`link:#quarkus-mybatis_quarkus.mybatis.vfs-impl[quarkus.mybatis.vfs-impl]`
+
+[.description]
+--
+MyBatis vfsImpl
+--|string 
+|
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.use-actual-param-name]]`link:#quarkus-mybatis_quarkus.mybatis.use-actual-param-name[quarkus.mybatis.use-actual-param-name]`
+
+[.description]
+--
+MyBatis useActualParamName
+--|boolean 
+|`true`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.configuration-factory]]`link:#quarkus-mybatis_quarkus.mybatis.configuration-factory[quarkus.mybatis.configuration-factory]`
+
+[.description]
+--
+MyBatis configurationFactory
+--|string 
+|
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.shrink-whitespaces-in-sql]]`link:#quarkus-mybatis_quarkus.mybatis.shrink-whitespaces-in-sql[quarkus.mybatis.shrink-whitespaces-in-sql]`
+
+[.description]
+--
+MyBatis shrinkWhitespacesInSql
+--|boolean 
+|`false`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-mybatis_quarkus.mybatis.default-sql-provider-type]]`link:#quarkus-mybatis_quarkus.mybatis.default-sql-provider-type[quarkus.mybatis.default-sql-provider-type]`
+
+[.description]
+--
+MyBatis defaultSqlProviderType
+--|string 
+|
 
 |===

--- a/runtime/src/main/java/io/quarkiverse/mybatis/runtime/MyBatisRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/mybatis/runtime/MyBatisRecorder.java
@@ -44,7 +44,6 @@ public class MyBatisRecorder {
             String dataSourceName,
             List<String> mappers) {
         Configuration configuration = createConfiguration(myBatisRuntimeConfig, dataSourceName, mappers);
-        logIfDebugEnabledConfigurationProperties(configuration);
         SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);
         return new RuntimeValue<>(sqlSessionFactory);
     }
@@ -67,6 +66,7 @@ public class MyBatisRecorder {
         configuration.setUseColumnLabel(myBatisRuntimeConfig.useColumnLabel);
         configuration.setUseGeneratedKeys(myBatisRuntimeConfig.useGeneratedKeys);
         configuration.setAutoMappingBehavior(myBatisRuntimeConfig.autoMappingBehavior);
+        configuration.setAutoMappingUnknownColumnBehavior(myBatisRuntimeConfig.autoMappingUnknownColumnBehavior);
         configuration.setDefaultExecutorType(myBatisRuntimeConfig.defaultExecutorType);
         myBatisRuntimeConfig.defaultStatementTimeout.ifPresent(configuration::setDefaultStatementTimeout);
         myBatisRuntimeConfig.defaultFetchSize.ifPresent(configuration::setDefaultFetchSize);
@@ -148,42 +148,6 @@ public class MyBatisRecorder {
             }
         }
         return configuration;
-    }
-
-    private void logIfDebugEnabledConfigurationProperties(Configuration configuration) {
-        LOG.debug("--------------------------------------------------------");
-        LOG.debug("MyBatis Configuration properties:");
-        LOG.debug("cacheEnabled: " + configuration.isCacheEnabled());
-        LOG.debug("lazyLoadingEnabled: " + configuration.isLazyLoadingEnabled());
-        LOG.debug("aggressiveLazyLoading: " + configuration.isAggressiveLazyLoading());
-        LOG.debug("multipleResultSetsEnabled: " + configuration.isMultipleResultSetsEnabled());
-        LOG.debug("useColumnLabel: " + configuration.isUseColumnLabel());
-        LOG.debug("useGeneratedKeys: " + configuration.isUseGeneratedKeys());
-        LOG.debug("autoMappingBehavior: " + configuration.getAutoMappingBehavior());
-        LOG.debug("autoMappingUnknownColumnBehavior: " + configuration.getAutoMappingUnknownColumnBehavior());
-        LOG.debug("defaultExecutorType: " + configuration.getDefaultExecutorType());
-        LOG.debug("defaultStatementTimeout: " + configuration.getDefaultStatementTimeout());
-        LOG.debug("defaultFetchSize: " + configuration.getDefaultFetchSize());
-        LOG.debug("defaultResultSetType: " + configuration.getDefaultResultSetType());
-        LOG.debug("safeRowBoundsEnabled: " + configuration.isSafeRowBoundsEnabled());
-        LOG.debug("safeResultHandlerEnabled: " + configuration.isSafeResultHandlerEnabled());
-        LOG.debug("mapUnderscoreToCamelCase: " + configuration.isMapUnderscoreToCamelCase());
-        LOG.debug("localCacheScope: " + configuration.getLocalCacheScope());
-        LOG.debug("jdbcTypeForNull: " + configuration.getJdbcTypeForNull());
-        LOG.debug("lazyLoadTriggerMethods: " + configuration.getLazyLoadTriggerMethods());
-        LOG.debug("defaultScriptingLanguage: " + configuration.getDefaultScriptingLanguageInstance());
-        LOG.debug("callSettersOnNulls: " + configuration.isCallSettersOnNulls());
-        LOG.debug("returnInstanceForEmptyRow: " + configuration.isReturnInstanceForEmptyRow());
-        LOG.debug("logPrefix: " + configuration.getLogPrefix());
-        LOG.debug("logImpl: " + configuration.getLogImpl());
-        LOG.debug("proxyFactory: " + configuration.getProxyFactory());
-        LOG.debug("vfsImpl: " + configuration.getVfsImpl());
-        LOG.debug("useActualParamName: " + configuration.isUseActualParamName());
-        LOG.debug("configurationFactory: " + configuration.getConfigurationFactory());
-        LOG.debug("shrinkWhitespacesInSql: " + configuration.isShrinkWhitespacesInSql());
-        LOG.debug("defaultSqlProviderType: " + configuration.getDefaultSqlProviderType());
-        LOG.debug("--------------------------------------------------------");
-
     }
 
     public RuntimeValue<SqlSessionManager> createSqlSessionManager(RuntimeValue<SqlSessionFactory> sqlSessionFactory) {

--- a/runtime/src/main/java/io/quarkiverse/mybatis/runtime/MyBatisRuntimeConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/mybatis/runtime/MyBatisRuntimeConfig.java
@@ -41,12 +41,6 @@ public class MyBatisRuntimeConfig {
     public Optional<String> initialSql;
 
     /**
-     * MyBatis mapUnderscoreToCamelCase
-     */
-    @ConfigItem(defaultValue = "false")
-    public boolean mapUnderscoreToCamelCase;
-
-    /**
      * MyBatis cacheEnabled
      */
     @ConfigItem(defaultValue = "true")
@@ -123,6 +117,12 @@ public class MyBatisRuntimeConfig {
      */
     @ConfigItem(defaultValue = "true")
     public boolean safeResultHandlerEnabled;
+
+    /**
+     * MyBatis mapUnderscoreToCamelCase
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean mapUnderscoreToCamelCase;
 
     /**
      * MyBatis multipleResultSetsEnabled

--- a/runtime/src/main/java/io/quarkiverse/mybatis/runtime/MyBatisRuntimeConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/mybatis/runtime/MyBatisRuntimeConfig.java
@@ -1,6 +1,14 @@
 package io.quarkiverse.mybatis.runtime;
 
 import java.util.Optional;
+import java.util.Set;
+
+import org.apache.ibatis.mapping.ResultSetType;
+import org.apache.ibatis.session.AutoMappingBehavior;
+import org.apache.ibatis.session.AutoMappingUnknownColumnBehavior;
+import org.apache.ibatis.session.ExecutorType;
+import org.apache.ibatis.session.LocalCacheScope;
+import org.apache.ibatis.type.JdbcType;
 
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -36,6 +44,179 @@ public class MyBatisRuntimeConfig {
      * MyBatis mapUnderscoreToCamelCase
      */
     @ConfigItem(defaultValue = "false")
-    public String mapUnderscoreToCamelCase;
+    public boolean mapUnderscoreToCamelCase;
 
+    /**
+     * MyBatis cacheEnabled
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean cacheEnabled;
+
+    /**
+     * MyBatis lazyLoadingEnabled
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean lazyLoadingEnabled;
+
+    /**
+     * MyBatis aggressiveLazyLoading
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean aggressiveLazyLoading;
+
+    /**
+     * MyBatis useColumnLabel
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean useColumnLabel;
+
+    /**
+     * MyBatis useGeneratedKeys
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean useGeneratedKeys;
+
+    /**
+     * MyBatis autoMappingBehavior
+     */
+    @ConfigItem(defaultValue = "PARTIAL")
+    public AutoMappingBehavior autoMappingBehavior;
+
+    /**
+     * MyBatis autoMappingUnknownColumnBehavior
+     */
+    @ConfigItem(defaultValue = "NONE")
+    public AutoMappingUnknownColumnBehavior autoMappingUnknownColumnBehavior;
+
+    /**
+     * MyBatis defaultExecutorType
+     */
+    @ConfigItem(defaultValue = "SIMPLE")
+    public ExecutorType defaultExecutorType;
+
+    /**
+     * MyBatis defaultStatementTimeout
+     */
+    @ConfigItem
+    public Optional<Integer> defaultStatementTimeout;
+
+    /**
+     * MyBatis defaultFetchSize
+     */
+    @ConfigItem
+    public Optional<Integer> defaultFetchSize;
+
+    /**
+     * MyBatis defaultResultSetType
+     */
+    @ConfigItem
+    public Optional<ResultSetType> defaultResultSetType;
+
+    /**
+     * MyBatis safeRowBoundsEnabled
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean safeRowBoundsEnabled;
+
+    /**
+     * MyBatis safeResultHandlerEnabled
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean safeResultHandlerEnabled;
+
+    /**
+     * MyBatis multipleResultSetsEnabled
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean multipleResultSetsEnabled;
+
+    /**
+     * MyBatis localCacheScope
+     */
+    @ConfigItem(defaultValue = "SESSION")
+    public LocalCacheScope localCacheScope;
+
+    /**
+     * MyBatis jdbcTypeForNull
+     */
+    @ConfigItem(defaultValue = "OTHER")
+    public JdbcType jdbcTypeForNull;
+
+    /**
+     * MyBatis lazyLoadTriggerMethods
+     */
+    @ConfigItem(defaultValue = "equals,clone,hashCode,toString")
+    public Set<String> lazyLoadTriggerMethods;
+
+    /**
+     * MyBatis defaultScriptingLanguage
+     */
+    @ConfigItem(defaultValue = "org.apache.ibatis.scripting.xmltags.XMLLanguageDriver")
+    public String defaultScriptingLanguage;
+
+    /**
+     * MyBatis defaultEnumTypeHandler
+     */
+    @ConfigItem(defaultValue = "org.apache.ibatis.type.EnumTypeHandler")
+    public String defaultEnumTypeHandler;
+
+    /**
+     * MyBatis callSettersOnNulls
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean callSettersOnNulls;
+
+    /**
+     * MyBatis returnInstanceForEmptyRow
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean returnInstanceForEmptyRow;
+
+    /**
+     * MyBatis logPrefix
+     */
+    @ConfigItem
+    public Optional<String> logPrefix;
+
+    /**
+     * MyBatis logImpl
+     */
+    @ConfigItem
+    public Optional<String> logImpl;
+
+    /**
+     * MyBatis proxyFactory
+     */
+    @ConfigItem(defaultValue = "JAVASSIST")
+    public String proxyFactory;
+
+    /**
+     * MyBatis vfsImpl
+     */
+    @ConfigItem
+    public Optional<String> vfsImpl;
+
+    /**
+     * MyBatis useActualParamName
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean useActualParamName;
+
+    /**
+     * MyBatis configurationFactory
+     */
+    @ConfigItem
+    public Optional<String> configurationFactory;
+
+    /**
+     * MyBatis shrinkWhitespacesInSql
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean shrinkWhitespacesInSql;
+
+    /**
+     * MyBatis defaultSqlProviderType
+     */
+    @ConfigItem
+    public Optional<String> defaultSqlProviderType;
 }


### PR DESCRIPTION
https://mybatis.org/mybatis-3/configuration.html#settings

```2021-03-16 22:07:54 |  [DEBUG] MyBatisRecorder - --------------------------------------------------------
2021-03-16 22:07:54 |  [DEBUG] MyBatisRecorder - MyBatis Configuration properties:
2021-03-16 22:07:54 |  [DEBUG] MyBatisRecorder - cacheEnabled: false
2021-03-16 22:07:54 |  [DEBUG] MyBatisRecorder - lazyLoadingEnabled: true
2021-03-16 22:07:54 |  [DEBUG] MyBatisRecorder - aggressiveLazyLoading: true
2021-03-16 22:07:54 |  [DEBUG] MyBatisRecorder - multipleResultSetsEnabled: false
2021-03-16 22:07:54 |  [DEBUG] MyBatisRecorder - useColumnLabel: false
2021-03-16 22:07:54 |  [DEBUG] MyBatisRecorder - useGeneratedKeys: true
2021-03-16 22:07:54 |  [DEBUG] MyBatisRecorder - autoMappingBehavior: FULL
2021-03-16 22:07:54 |  [DEBUG] MyBatisRecorder - autoMappingUnknownColumnBehavior: NONE
2021-03-16 22:07:54 |  [DEBUG] MyBatisRecorder - defaultExecutorType: SIMPLE
2021-03-16 22:07:54 |  [DEBUG] MyBatisRecorder - defaultStatementTimeout: 3000
2021-03-16 22:07:54 |  [DEBUG] MyBatisRecorder - defaultFetchSize: 50
2021-03-16 22:07:54 |  [DEBUG] MyBatisRecorder - defaultResultSetType: FORWARD_ONLY
2021-03-16 22:07:54 |  [DEBUG] MyBatisRecorder - safeRowBoundsEnabled: true
2021-03-16 22:07:54 |  [DEBUG] MyBatisRecorder - safeResultHandlerEnabled: false
2021-03-16 22:07:54 |  [DEBUG] MyBatisRecorder - mapUnderscoreToCamelCase: true
2021-03-16 22:07:54 |  [DEBUG] MyBatisRecorder - localCacheScope: STATEMENT
2021-03-16 22:07:54 |  [DEBUG] MyBatisRecorder - jdbcTypeForNull: DECIMAL
2021-03-16 22:07:54 |  [DEBUG] MyBatisRecorder - lazyLoadTriggerMethods: [equals, hashCode]
2021-03-16 22:07:54 |  [DEBUG] MyBatisRecorder - defaultScriptingLanguage: org.apache.ibatis.scripting.xmltags.XMLLanguageDriver@4ff5f725
2021-03-16 22:07:54 |  [DEBUG] MyBatisRecorder - callSettersOnNulls: true
2021-03-16 22:07:54 |  [DEBUG] MyBatisRecorder - returnInstanceForEmptyRow: true
2021-03-16 22:07:54 |  [DEBUG] MyBatisRecorder - logPrefix: test
2021-03-16 22:07:54 |  [DEBUG] MyBatisRecorder - logImpl: null
2021-03-16 22:07:54 |  [DEBUG] MyBatisRecorder - proxyFactory: org.apache.ibatis.executor.loader.javassist.JavassistProxyFactory@5170a01
2021-03-16 22:07:54 |  [DEBUG] MyBatisRecorder - vfsImpl: null
2021-03-16 22:07:54 |  [DEBUG] MyBatisRecorder - useActualParamName: false
2021-03-16 22:07:54 |  [DEBUG] MyBatisRecorder - configurationFactory: null
2021-03-16 22:07:54 |  [DEBUG] MyBatisRecorder - shrinkWhitespacesInSql: true
2021-03-16 22:07:54 |  [DEBUG] MyBatisRecorder - defaultSqlProviderType: null
2021-03-16 22:07:54 |  [DEBUG] MyBatisRecorder - --------------------------------------------------------
```