### PR TITLE
Fix enum field mapping in native mode

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/mybatis/deployment/MyBatisProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/mybatis/deployment/MyBatisProcessor.java
@@ -21,6 +21,7 @@ import org.apache.ibatis.javassist.util.proxy.ProxyFactory;
 import org.apache.ibatis.logging.log4j.Log4jImpl;
 import org.apache.ibatis.scripting.defaults.RawLanguageDriver;
 import org.apache.ibatis.scripting.xmltags.XMLLanguageDriver;
+import org.apache.ibatis.type.EnumTypeHandler;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.DotName;
@@ -74,7 +75,8 @@ class MyBatisProcessor {
                 Result.class,
                 Results.class,
                 ResultType.class,
-                ResultMap.class));
+                ResultMap.class,
+                EnumTypeHandler.class));
 
         reflectiveClass.produce(new ReflectiveClassBuildItem(true, true,
                 PerpetualCache.class, LruCache.class));


### PR DESCRIPTION
If pojo has enum fields then MyBatis mapper method fails in native mode with the cause:
```
Cause: org.apache.ibatis.type.TypeException: Unable to find a usable constructor for class org.apache.ibatis.type.EnumTypeHandler
```
It could be fixed by adding following lines to `reflection-config.json`:
```json
 {
    "name" : "org.apache.ibatis.type.EnumTypeHandler",
    "allDeclaredConstructors" : true
  }
```