### PR TITLE
Support mybatis-plus

### DIFF
--- a/mybatis-plus/deployment/pom.xml
+++ b/mybatis-plus/deployment/pom.xml
@@ -13,12 +13,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-arc-deployment</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-agroal-deployment</artifactId>
+            <groupId>io.quarkiverse.mybatis</groupId>
+            <artifactId>quarkus-mybatis-deployment</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.mybatis</groupId>

--- a/mybatis-plus/deployment/src/main/java/io/quarkiverse/mybatis/plus/deployment/MyBatisPlusProcessor.java
+++ b/mybatis-plus/deployment/src/main/java/io/quarkiverse/mybatis/plus/deployment/MyBatisPlusProcessor.java
@@ -1,0 +1,35 @@
+package io.quarkiverse.mybatis.plus.deployment;
+
+import org.jboss.jandex.DotName;
+
+import com.baomidou.mybatisplus.core.MybatisSqlSessionFactoryBuilder;
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+
+import io.quarkiverse.mybatis.deployment.ConfigurationFactoryBuildItem;
+import io.quarkiverse.mybatis.deployment.SqlSessionFactoryBuilderBuildItem;
+import io.quarkiverse.mybatis.plus.runtime.MyBatisPlusConfigurationFactory;
+import io.quarkiverse.mybatis.runtime.meta.MapperDataSource;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+
+public class MyBatisPlusProcessor {
+
+    private static final String FEATURE = "mybatis-plus";
+    private static final DotName MYBATIS_PLUS_MAPPER = DotName.createSimple(BaseMapper.class.getName());
+    private static final DotName MYBATIS_MAPPER_DATA_SOURCE = DotName.createSimple(MapperDataSource.class.getName());
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
+
+    @BuildStep
+    ConfigurationFactoryBuildItem createConfigurationFactory() {
+        return new ConfigurationFactoryBuildItem(new MyBatisPlusConfigurationFactory());
+    }
+
+    @BuildStep
+    SqlSessionFactoryBuilderBuildItem createSqlSessionFactoryBuilder() {
+        return new SqlSessionFactoryBuilderBuildItem(new MybatisSqlSessionFactoryBuilder());
+    }
+}

--- a/mybatis-plus/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/mybatis-plus/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 2.0.1.Final
+:quarkus-version: 2.2.1.Final
 :quarkus-mybatis-plus-version: 0.0.9
 
 :mybatis-root-url: https://mybatis.org/mybatis-3/

--- a/mybatis-plus/integration-tests/src/main/java/io/quarkiverse/it/mybatis/plus/MyBatisPlusResource.java
+++ b/mybatis-plus/integration-tests/src/main/java/io/quarkiverse/it/mybatis/plus/MyBatisPlusResource.java
@@ -1,0 +1,21 @@
+package io.quarkiverse.it.mybatis.plus;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/mybatis/plus")
+public class MyBatisPlusResource {
+    @Inject
+    UserMapper userMapper;
+
+    @Path("/user/{id}")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public User getUser(@PathParam("id") Integer id) {
+        return userMapper.selectById(id);
+    }
+}

--- a/mybatis-plus/integration-tests/src/main/java/io/quarkiverse/it/mybatis/plus/User.java
+++ b/mybatis-plus/integration-tests/src/main/java/io/quarkiverse/it/mybatis/plus/User.java
@@ -1,0 +1,37 @@
+package io.quarkiverse.it.mybatis.plus;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+import com.baomidou.mybatisplus.annotation.TableName;
+
+@TableName("USERS")
+public class User implements Serializable {
+    private Integer id;
+    private String name;
+    private UUID externalId;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public UUID getExternalId() {
+        return externalId;
+    }
+
+    public void setExternalId(UUID externalId) {
+        this.externalId = externalId;
+    }
+}

--- a/mybatis-plus/integration-tests/src/main/java/io/quarkiverse/it/mybatis/plus/UserMapper.java
+++ b/mybatis-plus/integration-tests/src/main/java/io/quarkiverse/it/mybatis/plus/UserMapper.java
@@ -1,0 +1,9 @@
+package io.quarkiverse.it.mybatis.plus;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+
+@Mapper
+public interface UserMapper extends BaseMapper<User> {
+}

--- a/mybatis-plus/integration-tests/src/main/java/io/quarkiverse/it/mybatis/plus/UuidTypeHandler.java
+++ b/mybatis-plus/integration-tests/src/main/java/io/quarkiverse/it/mybatis/plus/UuidTypeHandler.java
@@ -1,0 +1,42 @@
+package io.quarkiverse.it.mybatis.plus;
+
+import java.sql.*;
+import java.util.UUID;
+
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.MappedTypes;
+
+@MappedTypes(UUID.class)
+public class UuidTypeHandler extends BaseTypeHandler<UUID> {
+
+    public static UUID fromStringAllowNulls(String uuid) {
+        if (uuid == null || uuid.trim().equals("")) {
+            return null;
+        } else {
+            return UUID.fromString(uuid);
+        }
+    }
+
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int i, UUID parameter, JdbcType jdbcType) throws SQLException {
+        // note the difference in how H2 wants to persist a UUID
+        ps.setObject(i, parameter);
+    }
+
+    @Override
+    public UUID getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        return fromStringAllowNulls(rs.getString(columnName));
+    }
+
+    @Override
+    public UUID getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        return fromStringAllowNulls(rs.getString(columnIndex));
+    }
+
+    @Override
+    public UUID getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        return fromStringAllowNulls(cs.getString(columnIndex));
+    }
+
+}

--- a/mybatis-plus/integration-tests/src/main/resources/application.properties
+++ b/mybatis-plus/integration-tests/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+# H2
+quarkus.datasource.db-kind=h2
+quarkus.datasource.username=username-default
+quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:default
+quarkus.mybatis.initial-sql=insert.sql
+

--- a/mybatis-plus/integration-tests/src/main/resources/insert.sql
+++ b/mybatis-plus/integration-tests/src/main/resources/insert.sql
@@ -1,0 +1,24 @@
+DROP TABLE USERS IF EXISTS;
+DROP TABLE BOOKS IF EXISTS;
+
+CREATE TABLE USERS (
+    id integer not null primary key,
+    name varchar(80) not null,
+    externalId uuid not null
+);
+
+CREATE TABLE BOOKS (
+    id integer not null primary key,
+    title varchar(80) not null,
+    author_id integer not null,
+
+    foreign key(author_id) references USERS(id)
+);
+
+DELETE FROM users;
+insert into users (id, name, externalId) values (1, 'Test User1', 'ccb16b65-8924-4c3f-8c55-681d85a16e79');
+insert into users (id, name, externalId) values (2, 'Test User2', 'ae43f233-0b69-4c4e-bfa9-656c475150ad');
+insert into users (id, name, externalId) values (3, 'Test User3', '5640e179-466c-427e-9747-4cfac09a2f9a');
+
+DELETE from books;
+insert into books(id, title, author_id) values (1, 'Test Title', 1);

--- a/mybatis-plus/integration-tests/src/test/java/io/quarkiverse/it/mybatis/plus/MyBatisPlusTest.java
+++ b/mybatis-plus/integration-tests/src/test/java/io/quarkiverse/it/mybatis/plus/MyBatisPlusTest.java
@@ -1,0 +1,18 @@
+package io.quarkiverse.it.mybatis.plus;
+
+import static org.hamcrest.core.Is.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+public class MyBatisPlusTest {
+
+    @Test
+    public void test() {
+        RestAssured.when().get("/mybatis/plus/user/1").then()
+                .body(is("{\"id\":1,\"name\":\"Test User1\",\"externalId\":\"ccb16b65-8924-4c3f-8c55-681d85a16e79\"}"));
+    }
+}

--- a/mybatis-plus/integration-tests/src/test/java/io/quarkiverse/it/mybatis/plus/TestResources.java
+++ b/mybatis-plus/integration-tests/src/test/java/io/quarkiverse/it/mybatis/plus/TestResources.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.it.mybatis.plus;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.h2.H2DatabaseTestResource;
+
+@QuarkusTestResource(H2DatabaseTestResource.class)
+public class TestResources {
+}

--- a/mybatis-plus/runtime/pom.xml
+++ b/mybatis-plus/runtime/pom.xml
@@ -14,12 +14,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-arc</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-agroal</artifactId>
+            <groupId>io.quarkiverse.mybatis</groupId>
+            <artifactId>quarkus-mybatis</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.baomidou</groupId>

--- a/mybatis-plus/runtime/src/main/java/io/quarkiverse/mybatis/plus/runtime/MyBatisPlusConfigurationFactory.java
+++ b/mybatis-plus/runtime/src/main/java/io/quarkiverse/mybatis/plus/runtime/MyBatisPlusConfigurationFactory.java
@@ -1,0 +1,14 @@
+package io.quarkiverse.mybatis.plus.runtime;
+
+import org.apache.ibatis.session.Configuration;
+
+import com.baomidou.mybatisplus.core.MybatisConfiguration;
+
+import io.quarkiverse.mybatis.runtime.ConfigurationFactory;
+
+public class MyBatisPlusConfigurationFactory implements ConfigurationFactory {
+    @Override
+    public Configuration createConfiguration() {
+        return new MybatisConfiguration();
+    }
+}

--- a/mybatis/deployment/src/main/java/io/quarkiverse/mybatis/deployment/ConfigurationFactoryBuildItem.java
+++ b/mybatis/deployment/src/main/java/io/quarkiverse/mybatis/deployment/ConfigurationFactoryBuildItem.java
@@ -1,0 +1,16 @@
+package io.quarkiverse.mybatis.deployment;
+
+import io.quarkiverse.mybatis.runtime.ConfigurationFactory;
+import io.quarkus.builder.item.SimpleBuildItem;
+
+public final class ConfigurationFactoryBuildItem extends SimpleBuildItem {
+    private final ConfigurationFactory factory;
+
+    public ConfigurationFactoryBuildItem(ConfigurationFactory factory) {
+        this.factory = factory;
+    }
+
+    public ConfigurationFactory getFactory() {
+        return factory;
+    }
+}

--- a/mybatis/deployment/src/main/java/io/quarkiverse/mybatis/deployment/SqlSessionFactoryBuilderBuildItem.java
+++ b/mybatis/deployment/src/main/java/io/quarkiverse/mybatis/deployment/SqlSessionFactoryBuilderBuildItem.java
@@ -1,0 +1,17 @@
+package io.quarkiverse.mybatis.deployment;
+
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+public final class SqlSessionFactoryBuilderBuildItem extends SimpleBuildItem {
+    private final SqlSessionFactoryBuilder builder;
+
+    public SqlSessionFactoryBuilderBuildItem(SqlSessionFactoryBuilder builder) {
+        this.builder = builder;
+    }
+
+    public SqlSessionFactoryBuilder getBuilder() {
+        return builder;
+    }
+}

--- a/mybatis/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/mybatis/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 2.0.1.Final
+:quarkus-version: 2.2.1.Final
 :quarkus-mybatis-version: 0.0.9
 
 :mybatis-root-url: https://mybatis.org/mybatis-3/

--- a/mybatis/runtime/src/main/java/io/quarkiverse/mybatis/runtime/ConfigurationFactory.java
+++ b/mybatis/runtime/src/main/java/io/quarkiverse/mybatis/runtime/ConfigurationFactory.java
@@ -1,0 +1,7 @@
+package io.quarkiverse.mybatis.runtime;
+
+import org.apache.ibatis.session.Configuration;
+
+public interface ConfigurationFactory {
+    Configuration createConfiguration();
+}

--- a/mybatis/runtime/src/main/java/io/quarkiverse/mybatis/runtime/MyBatisConfigurationFactory.java
+++ b/mybatis/runtime/src/main/java/io/quarkiverse/mybatis/runtime/MyBatisConfigurationFactory.java
@@ -1,0 +1,10 @@
+package io.quarkiverse.mybatis.runtime;
+
+import org.apache.ibatis.session.Configuration;
+
+public class MyBatisConfigurationFactory implements ConfigurationFactory {
+    @Override
+    public Configuration createConfiguration() {
+        return new Configuration();
+    }
+}

--- a/mybatis/runtime/src/main/java/io/quarkiverse/mybatis/runtime/MyBatisRecorder.java
+++ b/mybatis/runtime/src/main/java/io/quarkiverse/mybatis/runtime/MyBatisRecorder.java
@@ -59,17 +59,24 @@ public class MyBatisRecorder {
         return new RuntimeValue<>(sqlSessionFactory);
     }
 
+    public RuntimeValue<Configuration> createConfiguration() {
+        return new RuntimeValue<>(new Configuration());
+    }
+
     public RuntimeValue<SqlSessionFactory> createSqlSessionFactory(
+            ConfigurationFactory configurationFactory,
+            SqlSessionFactoryBuilder builder,
             MyBatisRuntimeConfig myBatisRuntimeConfig,
             MyBatisDataSourceRuntimeConfig myBatisDataSourceRuntimeConfig,
             String dataSourceName,
             List<String> mappers,
             List<String> mappedTypes,
             List<String> mappedJdbcTypes) {
-        Configuration configuration = createConfiguration(myBatisRuntimeConfig, myBatisDataSourceRuntimeConfig, dataSourceName);
+        Configuration configuration = configurationFactory.createConfiguration();
+        setupConfiguration(configuration, myBatisRuntimeConfig, myBatisDataSourceRuntimeConfig, dataSourceName);
         addMappers(configuration, mappedTypes, mappedJdbcTypes, mappers);
 
-        SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);
+        SqlSessionFactory sqlSessionFactory = builder.build(configuration);
         return new RuntimeValue<>(sqlSessionFactory);
     }
 
@@ -100,11 +107,10 @@ public class MyBatisRecorder {
         }
     }
 
-    private Configuration createConfiguration(MyBatisRuntimeConfig runtimeConfig,
+    private Configuration setupConfiguration(Configuration configuration,
+            MyBatisRuntimeConfig runtimeConfig,
             MyBatisDataSourceRuntimeConfig dataSourceRuntimeConfig,
             String dataSourceName) {
-        Configuration configuration = new Configuration();
-
         TransactionFactory factory;
         String transactionFactory = dataSourceRuntimeConfig != null && dataSourceRuntimeConfig.transactionFactory.isPresent()
                 ? dataSourceRuntimeConfig.transactionFactory.get()

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
         <quarkus.version>2.2.1.Final</quarkus.version>
         <mybatis.version>3.5.7</mybatis.version>
-	<mybatis-plus.version>3.4.3.1</mybatis-plus.version>
+	<mybatis-plus.version>3.4.3</mybatis-plus.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
This replaces https://github.com/quarkiverse/quarkus-mybatis/pull/110 to add the mybatis-plus support by using the BuildItem to introduce the different implmentation of Configuration and SqlSessionFactory in mybatis-plus.

It has to stick with mybatis-plus 3.4.3 due to https://github.com/baomidou/mybatis-plus/issues/3755. And @zohar-soul , could you please to take a look at the new release 3.4.3.3 which could set the GenericTypeReoslver of our own.

Another issue is that we have to use ```@Mapper``` to indicate the mapper class right now.