### PR TITLE
Fix dead link

### DIFF
--- a/mybatis-plus/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/mybatis-plus/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -3,7 +3,7 @@ name: "An powerful enhanced toolkit of MyBatis for simplify development"
 metadata:
   keywords:
   - "mybatis-plus"
-  guide: "https://quarkus.io/guides/mybatis-plus"
+  guide: "https://quarkiverse.github.io/quarkiverse-docs/quarkus-mybatis/dev/"
   categories:
   - "data"
   status: "stable"


### PR DESCRIPTION
The extension metadata has a dead link. I've corrected it to what I think is the best available link. 