### PR TITLE
Use shorter name, rather than replica of description

### DIFF
--- a/mybatis-plus/runtime/pom.xml
+++ b/mybatis-plus/runtime/pom.xml
@@ -10,7 +10,7 @@
 
     <artifactId>quarkus-mybatis-plus</artifactId>
     <name>Quarkus - Mybatis Plus - Runtime</name>
-    <description>An powerful enhanced toolkit of MyBatis for simplify development</description>
+    <description>A powerful enhanced toolkit of MyBatis to simplify development</description>
 
     <dependencies>
         <dependency>

--- a/mybatis-plus/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/mybatis-plus/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,5 +1,5 @@
 ---
-name: "An powerful enhanced toolkit of MyBatis for simplify development"
+name: "MyBatis Plus"
 metadata:
   keywords:
   - "mybatis-plus"


### PR DESCRIPTION
I've spotted another little issue with the extension metadata for the MyBatis Plus extension. The name should be short, rather than description-length, because we show it in various lists.