### PR TITLE
Fix #215: Add hot deployment support for XML mappers

### DIFF
--- a/mybatis/deployment/src/main/java/io/quarkiverse/mybatis/deployment/MyBatisProcessor.java
+++ b/mybatis/deployment/src/main/java/io/quarkiverse/mybatis/deployment/MyBatisProcessor.java
@@ -59,6 +59,7 @@ import io.quarkus.deployment.annotations.Overridable;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageProxyDefinitionBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
@@ -244,6 +245,20 @@ public class MyBatisProcessor {
         if (config.xmlconfig().enable()) {
             xmlConfig.produce(new MyBatisXmlConfigBuildItem("xmlconfig", true));
         }
+    }
+
+    @BuildStep
+    void registerXmlMappersForHotDeployment(MyBatisRuntimeConfig config,
+            BuildProducer<HotDeploymentWatchedFileBuildItem> hotDeploymentProducer) {
+        config.mapperLocations().ifPresent(mapperLocations -> {
+            for (String mapperLocation : mapperLocations) {
+                hotDeploymentProducer.produce(new HotDeploymentWatchedFileBuildItem(mapperLocation + "/**/*.xml"));
+            }
+        });
+
+        hotDeploymentProducer.produce(new HotDeploymentWatchedFileBuildItem("**/*Mapper.xml"));
+        hotDeploymentProducer.produce(new HotDeploymentWatchedFileBuildItem("mapper/**/*.xml"));
+        hotDeploymentProducer.produce(new HotDeploymentWatchedFileBuildItem("mappers/**/*.xml"));
     }
 
     @Record(ExecutionTime.STATIC_INIT)


### PR DESCRIPTION
## Summary
Implements live reload functionality for MyBatis XML mapper files during development. When XML mappers are modified, changes will now be automatically picked up without requiring manual application restarts.

## Changes
- Added `HotDeploymentWatchedFileBuildItem` support in `MyBatisProcessor`
- Watches configured `mapperLocations` directories for XML file changes  
- Includes common mapper patterns: `**/*Mapper.xml`, `mapper/**/*.xml`, `mappers/**/*.xml`
- Leverages Quarkus built-in hot deployment mechanism for seamless developer experience

## Test plan
- [x] Code compiles successfully with Java 17
- [x] No breaking changes to existing functionality
- [x] Follows established Quarkus patterns for hot deployment

Fixes #215

🤖 Generated with [Claude Code](https://claude.ai/code)